### PR TITLE
Terraform 1.x support

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 module "labels" {
-  source  = "cloudposse/label/terraform"
-  version = "0.5.1"
+  source  = "cloudposse/label/null"
+  version = "0.25.0"
 
   namespace = var.namespace
   stage     = var.stage


### PR DESCRIPTION
The current version of the athena module uses a deprecated version of `labels` module. 

using it 

```
module "aws-athena" {
  source  = "Adaptavist/aws-athena/module"
  version = "1.3.2"
  queries = {}
  namespace = "demo"
  name = "athena-poc"
  stage = "test"
}
```

gives error
```
terraform plan
╷
│ Error: Error in function call
│
│   on .terraform/modules/athena.labels/main.tf line 2, in locals:
│    2:   original_tags    = join(var.delimiter, compact(concat(list(var.namespace, var.stage, var.name), var.attributes)))
│     ├────────────────
│     │ var.name is a string, known only after apply
│     │ var.namespace is a string, known only after apply
│     │ var.stage is a string, known only after apply
│
│ Call to function "list" failed: the "list" function was deprecated in Terraform v0.12 and is no longer available; use tolist([ ... ]) syntax to write a literal list.
```

This patch fixes the issue.